### PR TITLE
crypto: fix a typo

### DIFF
--- a/drivers/crypto/msm/qce50.c
+++ b/drivers/crypto/msm/qce50.c
@@ -4680,7 +4680,7 @@ again:
 			pce_dev->intr_cadence = 0;
 			atomic_set(&pce_dev->bunch_cmd_seq, 0);
 			atomic_set(&pce_dev->last_intr_seq, 0);
-			pce_dev->cadence_flag = ~pce_dev->cadence_flag;
+			pce_dev->cadence_flag = !pce_dev->cadence_flag;
 		}
 	}
 


### PR DESCRIPTION
error: bitwise negation of a boolean expression always evaluates to 'true'; did you mean logical negation? [-Werror,-Wbool-operation]
                        pce_dev->cadence_flag = ~pce_dev->cadence_flag;
                                                ^~~~~~~~~~~~~~~~~~~~~~