### PR TITLE
power: fix a typo

### DIFF
--- a/drivers/power/supply/qcom/qpnp-fg-gen3.c
+++ b/drivers/power/supply/qcom/qpnp-fg-gen3.c
@@ -2709,7 +2709,7 @@ static void clear_cycle_counter(struct fg_chip *chip)
 	}
 	rc = fg_sram_write(chip, CYCLE_COUNT_WORD, CYCLE_COUNT_OFFSET,
 			(u8 *)&chip->cyc_ctr.count,
-			sizeof(chip->cyc_ctr.count) / sizeof(u8 *),
+			sizeof(chip->cyc_ctr.count) / (sizeof(u8 *)),
 			FG_IMA_DEFAULT);
 	if (rc < 0)
 		pr_err("failed to clear cycle counter rc=%d\n", rc);


### PR DESCRIPTION
error: expression does not compute the number of elements in this array; element type is 'u16' (aka 'unsigned short'), not 'u8 *' (aka 'unsigned char *') [-Werror,-Wsizeof-array-div]
                        sizeof(chip->cyc_ctr.count) / sizeof(u8 *),
                               ~~~~~~~~~~~~~~~~~~~  ^